### PR TITLE
[Core/Geometry] Remove indices management from `Coordinate/Group`

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -25,11 +25,10 @@ if(EXISTS ${CMAKE_CURRENT_LIST_DIR}/Data.h AND EXISTS
 
     find_package(nlohmann_json CONFIG REQUIRED)
 
-    target_link_libraries(opensemba_core opensemba_core_geometry
+    target_link_libraries(opensemba_core
                                               opensemba_core_physicalmodel
                                               opensemba_core_source
                                               opensemba_core_outputrequest
-                                              opensemba_core_filesystem
                                               opensemba_core_boundary
                                               nlohmann_json)
 endif()

--- a/src/core/geometry/coordinate/Group.h
+++ b/src/core/geometry/coordinate/Group.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <set>
 #include <type_traits>
+#include <map>
 
 #ifdef _MSC_VER
 #pragma warning(disable:4250)
@@ -30,33 +30,22 @@ public:
     Group(const std::vector<Math::CVecR3>&);
     Group(const std::vector<Math::CVecI3>&);
     
-    Group(const Group<C>&);
+    Group(const Group<C>&) = default;
 
     Group(Group<C>&&) noexcept = default;
-    
-    Group<C>& operator=(const Group<C>& rhs);
+
+    Group<C>& operator=(const Group<C>& rhs) = default;
     Group<C>& operator=(Group<C>&& rhs) = default;
 
     virtual ~Group() = default;
 
-    const CoordR3* getPos(const Math::CVecR3& pos) const;
-    const CoordI3* getPos(const Math::CVecI3& pos) const;
-
     template<typename VEC>
-    void addPos(VEC);
-
-    typename IdentifiableUnique<C>::iterator add(const std::unique_ptr<C>&);
-    typename IdentifiableUnique<C>::iterator add(std::unique_ptr<C>&&) final;
-    typename IdentifiableUnique<C>::iterator addAndAssignId(std::unique_ptr<C>&& item) final;
+    typename IdentifiableUnique<C>::iterator  addPos(VEC);
 
     void applyScalingFactor(const Math::Real factor);
-   
-private:
-    std::multiset<const CoordR3*, CoordComparator> indexUnstr_;
-    std::multiset<const CoordI3*, CoordComparator> indexStr_;
-    
-    void updateIndices();
-    void updateIndexEntry(const C*);
+
+    template<typename VEC>
+    const std::map<VEC, std::vector<const C*>> getIndex() const;
 };
 
 } /* namespace Coordinate */

--- a/src/core/geometry/coordinate/Group.h
+++ b/src/core/geometry/coordinate/Group.h
@@ -45,7 +45,7 @@ public:
     void applyScalingFactor(const Math::Real factor);
 
     template<typename VEC>
-    const std::map<VEC, std::vector<const C*>> getIndex() const;
+    std::map<VEC, std::vector<const C*>> getIndex() const;
 };
 
 } /* namespace Coordinate */

--- a/src/core/geometry/coordinate/Group.hpp
+++ b/src/core/geometry/coordinate/Group.hpp
@@ -42,7 +42,7 @@ void Group<C>::applyScalingFactor(const Math::Real factor)
 }
 
 template<typename C> template<typename VEC>
-const std::map<VEC, std::vector<const C*>> Group<C>::getIndex() const {
+std::map<VEC, std::vector<const C*>> Group<C>::getIndex() const {
     std::map<VEC, std::vector<const C*>> index;
 
     for (auto& c : *this) {

--- a/src/core/geometry/element/Hexahedron8.hpp
+++ b/src/core/geometry/element/Hexahedron8.hpp
@@ -37,11 +37,7 @@ Hexahedron8<T>::Hexahedron8(
     }
     std::vector<Math::Vector::Cartesian<T,3> > pos = box.getPos();
     for (std::size_t i = 0; i < numberOfCoordinates(); i++) {
-        v_[i] = cG.getPos(pos[i]);
-        if (v_[i] == nullptr) {
-            cG.addPos(pos[i]);
-            v_[i] = cG.getPos(pos[i]);
-        }
+        v_[i] = cG.addPos(pos[i])->get();
     }
 }
 

--- a/src/core/geometry/element/Line2.h
+++ b/src/core/geometry/element/Line2.h
@@ -77,7 +77,7 @@ private:
 
 typedef Element::Line2Base         Lin2;
 typedef Element::Line2<Math::Real> LinR2;
-typedef Element::Line2<Math::Int > LinI2;
+typedef Element::Line2<Math::Int> LinI2;
 
 } /* namespace Geometry */
 } /* namespace SEMBA */

--- a/src/core/geometry/element/Line2.hpp
+++ b/src/core/geometry/element/Line2.hpp
@@ -129,11 +129,7 @@ void Line2<T>::setCoordinates(
     }
     std::vector<Math::Vector::Cartesian<T,3> > pos = box.getPos();
     for (std::size_t i = 0; i < numberOfCoordinates(); i++) {
-        v_[i] = cG.getPos(pos[i]);
-        if (v_[i] == nullptr) {
-            cG.addPos(pos[i]);
-            v_[i] = cG.getPos(pos[i]);
-        }
+        v_[i] = cG.addPos(pos[i])->get();
     }
 }
 

--- a/src/core/geometry/element/Node.hpp
+++ b/src/core/geometry/element/Node.hpp
@@ -33,14 +33,8 @@ Node<T>::Node(Coordinate::Group<Coordinate::Coordinate<T,3> >& cG,
     if(!box.isPoint()) {
         throw Geometry::Error::Box::NotPoint();
     }
-    std::vector<Math::Vector::Cartesian<T,3> > pos = box.getPos();
-    for (std::size_t i = 0; i < numberOfCoordinates(); i++) {
-        v_[i] = cG.getPos(pos[i]);
-        if (v_[i] == nullptr) {
-            cG.addPos(pos[i]);
-            v_[i] = cG.getPos(pos[i]);
-        }
-    }
+
+    v_[0] = cG.addPos(box.getPos()[0])->get();
 }
 
 template<class T>

--- a/src/core/geometry/element/Quadrilateral4.hpp
+++ b/src/core/geometry/element/Quadrilateral4.hpp
@@ -48,11 +48,7 @@ Quadrilateral4<T>::Quadrilateral4(
     }
     std::vector<Math::Vector::Cartesian<T,3> > pos = box.getPos();
     for (std::size_t i = 0; i < numberOfCoordinates(); i++) {
-        v_[i] = cG.getPos(pos[i]);
-        if (v_[i] == nullptr) {
-            cG.addPos(pos[i]);
-            v_[i] = cG.getPos(pos[i]);
-        }
+        v_[i] = cG.addPos(pos[i])->get();
     }
 }
 

--- a/test/core/group/IdentifiableUniqueTest.cpp
+++ b/test/core/group/IdentifiableUniqueTest.cpp
@@ -20,7 +20,7 @@ protected:
     }
 };
 
-TEST_F(IdentifiableUniqueTest, copy_and_move_ctor) 
+TEST_F(IdentifiableUniqueTest, CopyAndMoveCtor) 
 {
     auto orig = buildGroupOfThreeLayers();
     std::size_t origSize = orig.size();
@@ -33,7 +33,8 @@ TEST_F(IdentifiableUniqueTest, copy_and_move_ctor)
     EXPECT_EQ(origSize, copied.size());
     EXPECT_EQ(0, orig.size());
 }
-TEST_F(IdentifiableUniqueTest, copy_and_move_assignment) 
+
+TEST_F(IdentifiableUniqueTest, CopyAndMoveAssignment) 
 {
     auto orig = buildGroupOfThreeLayers();
     std::size_t origSize = orig.size();
@@ -47,7 +48,7 @@ TEST_F(IdentifiableUniqueTest, copy_and_move_assignment)
     EXPECT_EQ(0, orig.size());
 }
 
-TEST_F(IdentifiableUniqueTest, deep_copy_and_move_add) 
+TEST_F(IdentifiableUniqueTest, DeepCopyAndMoveAdd) 
 {
     auto orig = buildGroupOfThreeLayers();
     orig.add(std::make_unique<Layer::Layer>(LayerId(5), "Melon"));
@@ -56,7 +57,7 @@ TEST_F(IdentifiableUniqueTest, deep_copy_and_move_add)
     EXPECT_EQ(5, orig.size());
 }
 
-TEST_F(IdentifiableUniqueTest, addAndAssignId) 
+TEST_F(IdentifiableUniqueTest, AddAndAssignId) 
 {
     auto orig(buildGroupOfThreeLayers());
     auto melon = std::make_unique<Layer::Layer>("Melon");
@@ -64,8 +65,8 @@ TEST_F(IdentifiableUniqueTest, addAndAssignId)
     EXPECT_EQ(LayerId(4), melonInGroup->getId());
 }
 
-TEST_F(IdentifiableUniqueTest, addAndAssignIds) 
-{    
+TEST_F(IdentifiableUniqueTest, AddAndAssignIds) 
+{
 	auto orig(buildGroupOfThreeLayers());
 
 	auto melonInGroup = orig.addAndAssignId(std::move(
@@ -90,4 +91,3 @@ TEST_F(IdentifiableUniqueTest, addAndAssignIds)
 	EXPECT_EQ(6, another.size());
 	EXPECT_EQ("Níspora", another.getId(LayerId(6))->getName());
 }
-

--- a/test/core/source/port/WaveguideRectangularTest.cpp
+++ b/test/core/source/port/WaveguideRectangularTest.cpp
@@ -18,7 +18,7 @@ class SourcePortWaveguideRectangularTest : public ::testing::Test {
         vector<Geometry::BoxI3> quadBoxes = plane.chop();
         Geometry::ElemId id(0);
         for (size_t i = 0; i < quadBoxes.size(); i++) {
-            surfs.add(std::make_unique<Geometry::QuaI4>(cG_, ++id,quadBoxes[i], nullptr, nullptr));
+            surfs.add(std::make_unique<Geometry::QuaI4>(cG_, ++id,quadBoxes[i]));
         }
 
         excMode = Port::Waveguide::ExcitationMode::TE;


### PR DESCRIPTION
Due to a bug detected in past conversations when dealing with `mesh` having a coordinate group with diferent amount of `coordinates` and `indices`, it would be good to find another solution for indexing. 

As there is no much usage of the following use case:
- Given a vector, find the coordinates having that position

it is proposed to add a helper method inside `Coordinate/Group` scope to construct a `map` between vectors and coordinates, on the fly.

Updated methods colliding with `getPos` and `test`s.