### PR TITLE
[Core | Exporters] Apply relevant changes of API due to usage of extended version in SEMBA

### DIFF
--- a/src/core/class/GroupIdentifiableUnique.h
+++ b/src/core/class/GroupIdentifiableUnique.h
@@ -129,29 +129,42 @@ template<typename T>
 typename GroupIdentifiableUnique<T>::iterator
 GroupIdentifiableUnique<T>::add(const std::unique_ptr<T>& elem)
 {
+    auto iteratorFound = items_.find(elem);
+    if (iteratorFound != items_.end()) {
+        items_.erase(iteratorFound);
+    }
+
     std::unique_ptr<T> res(dynamic_cast<T*>(elem->clone().release()));
     auto it = items_.insert(std::move(res));
     
-    if (it.second) {
-        return it.first;
-    }
-    else {
-        throw std::logic_error("Group: Duplicated Id " + elem->getId().toStr());
+    if (!it.second) {
+        throw std::logic_error(
+            "Group: Could not insert element with Id " + elem->getId().toStr() +
+            ". Another object with the same Id may have or may have not been deleted"
+        );
     }
 
+    return it.first;
 }
 
 template<typename T> 
 typename GroupIdentifiableUnique<T>::iterator
 GroupIdentifiableUnique<T>::add(std::unique_ptr<T>&& elem)
 {
+    auto iteratorFound = items_.find(elem);
+    if (iteratorFound != items_.end()) {
+        items_.erase(iteratorFound);
+    }
+
     auto it = items_.insert(std::move(elem));
-    if (it.second) {
-        return it.first;
+    if (!it.second) {
+        throw std::logic_error(
+            "Group: Could not insert element with Id " + elem->getId().toStr() +
+            ". Another object with the same Id may have or may have not been deleted"
+        );
     }
-    else {
-        throw std::logic_error("Group: Duplicated Id " + elem->getId().toStr());
-    }
+
+    return it.first;
 }
 
 template<typename T>

--- a/src/core/model/Model.h
+++ b/src/core/model/Model.h
@@ -13,6 +13,7 @@ class Model {
 public:
 	Model() = default;
 	Model(const M&, const PMGroup&);
+	Model(const Model& rhs);
 	Model& operator=(const Model& rhs);
 
 	M mesh;

--- a/src/core/model/Model.hpp
+++ b/src/core/model/Model.hpp
@@ -14,6 +14,14 @@ Model<M>::Model(
 }
 
 template<typename M>
+Model<M>::Model(const Model& rhs) {
+	mesh = rhs.mesh;
+	physicalModels = rhs.physicalModels;
+
+	mesh.reassignPointers(physicalModels);
+}
+
+template<typename M>
 Model<M>& Model<M>::operator=(const Model& rhs) {
 	mesh = rhs.mesh;
 	physicalModels = rhs.physicalModels;

--- a/src/core/util/wire/Group.h
+++ b/src/core/util/wire/Group.h
@@ -6,7 +6,7 @@
 #include <set>
 #include <type_traits>
 
-#include "Data.h"
+#include "ProblemDescription.h"
 #include "geometry/element/Polyline.h"
 #include "geometry/element/Line2.h"
 #include "geometry/graph/Vertices.h"
@@ -39,7 +39,8 @@ public:
                 Geometry::Element::Line<T>,
                 Geometry::Coordinate::Coordinate<T,3>> Graph;
 
-    Group(const Data&);
+    Group(const Model::UnstructuredModel&);
+    Group(const Model::StructuredModel&);
     ~Group();
 
     std::size_t numberOfWires() const { return wires_.size(); }
@@ -69,17 +70,18 @@ private:
 
     std::map<MatId, PhysicalModel::Wire::Extremes*> mats_;
 
-    void init_(const Data&);
-    Graph constructGraph_(const Data&);
-    void fillWiresInfo_(const Graph&,
-                        const Data&);
+    Graph constructGraph_(
+        std::vector<const Geometry::Element::Line<T>*>&,
+        const PMGroup&
+    );
+    void fillWiresInfo_(const Graph&, const SEMBA::PMGroup&);
     std::vector<std::vector<const Geometry::Element::Line<T>*>>
         getLines_(const Graph&);
     void getWireMats_(const PhysicalModel::Wire::Wire*& wireMat,
                       const PhysicalModel::Multiport::Multiport*& extremeL,
                       const PhysicalModel::Multiport::Multiport*& extremeR,
                       const std::vector<const Geometry::Element::Line<T>*>&,
-                      const Data&,
+                      const SEMBA::PMGroup&,
                       const Graph&);
     Geometry::Element::Polyline<T>* newWire_(
             const std::vector<const Geometry::Element::Line<T>*>& lines,

--- a/src/exporters/Exporter.h
+++ b/src/exporters/Exporter.h
@@ -5,7 +5,7 @@
 #include <cstring>
 #include <vector>
 
-#include "Data.h"
+#include "ProblemDescription.h"
 #include "geometry/mesh/Structured.h"
 
 namespace SEMBA {

--- a/src/exporters/gid/Exporter.h
+++ b/src/exporters/gid/Exporter.h
@@ -12,7 +12,7 @@ public:
     static const Math::CVecR3 pecColor, pmcColor, smaColor, pmlColor,
         sibcColor, emSourceColor;
 
-    Exporter(const Data& smb, const std::string& fn, GiD_PostMode mode = GiD_PostAscii);
+    Exporter(UnstructuredProblemDescription&, const std::string&, GiD_PostMode mode = GiD_PostAscii);
     virtual ~Exporter();
 
     void beginMesh(
@@ -40,8 +40,8 @@ private:
     GiD_FILE resultFile_;
     GiD_PostMode mode_;
 
-    void init_(const Data& smb, GiD_PostMode mode, const std::string& fn);
-    void writeMesh_(const Data& smb);
+    void init_(UnstructuredProblemDescription& smb, GiD_PostMode mode, const std::string& fn);
+    void writeMesh_(const UnstructuredProblemDescription& smb);
 
     void writeElements_(
             const ElemRView& elems,

--- a/src/exporters/vtk/Exporter.h
+++ b/src/exporters/vtk/Exporter.h
@@ -5,7 +5,7 @@
 #include <algorithm>
 
 #include "exporters/Exporter.h"
-#include "Data.h"
+#include "ProblemDescription.h"
 
 namespace SEMBA {
 namespace Exporters {
@@ -13,7 +13,7 @@ namespace VTK {
 
 class Exporter : public SEMBA::Exporters::Exporter {
 public:
-    Exporter(const Data& smb, const std::string& fn);
+    Exporter(const UnstructuredProblemDescription&, const std::string&);
     
 private:
     enum CELL_TYPES {
@@ -37,7 +37,7 @@ private:
         VTK_QUADRATIC_TETRA      = 24,
         VTK_QUADRATIC_HEXAHEDRON = 25
     };
-    void writeMesh_(const Data& smb);
+    void writeMesh_(const UnstructuredProblemDescription&);
     void writeFile_(const ElemRView& elems,
                     const std::string& name,
                     std::ofstream& outMain,

--- a/test/core/class/GroupIdentifiableUniqueTest.cpp
+++ b/test/core/class/GroupIdentifiableUniqueTest.cpp
@@ -1,5 +1,4 @@
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 #include "class/GroupIdentifiableUnique.h"
 #include "geometry/layer/layer.h"
@@ -98,9 +97,13 @@ TEST_F(GroupIdentifiableUniqueTest, DuplicatedIdShouldTriggerLogicException)
 {
     auto orig(buildGroupOfThreeLayers());
 
-    EXPECT_THAT(
-        [&]() {orig.add(std::make_unique<Layer::Layer>(LayerId(1), "Another Patata")); },
-        testing::ThrowsMessage<std::logic_error>(testing::HasSubstr("Group: Duplicated Id 1"))
-    );
+    EXPECT_EQ(orig.getId(LayerId(1))->getName(), "Patata");
 
+    orig.add(std::make_unique<Layer::Layer>(LayerId(1), "Another Patata"));
+
+    EXPECT_EQ(orig.getId(LayerId(1))->getName(), "Another_Patata");
+
+    for (const auto& item : orig) {
+        EXPECT_TRUE(item->getName() != "Patata");
+    }
 }


### PR DESCRIPTION
Due to the latest changes in `SEMBA`, it is necessary to update entry point types of some `OpenSEMBA`'s classes. Simplify workflow following the default `ProblemDescription` as `Unstructured`.