### PR TITLE
[PARSER] Fix stl parser processing duplicated coordinates

### DIFF
--- a/src/core/physicalModel/PriorityMaterial.cpp
+++ b/src/core/physicalModel/PriorityMaterial.cpp
@@ -3,17 +3,25 @@
 namespace SEMBA {
 namespace PhysicalModel {
 
-PriorityMaterial::PriorityMaterial(const Id& matId, const std::string& name, int priority) :
+PriorityMaterial::PriorityMaterial(
+	const Id& matId, 
+	const std::string& name, 
+	int priority,
+	bool treatAsVolume) :
 	Identifiable<Id>(matId),
 	PhysicalModel(name),
-	priority_(priority)
+	priority_(priority),
+	treatAsVolume_(treatAsVolume)
 {}
 
-PriorityMaterial::PriorityMaterial(const PriorityMaterial& rhs) :
-	Identifiable<Id>(rhs),
-	PhysicalModel(rhs) 
+bool PriorityMaterial::operator==(const PriorityMaterial& rhs) const
 {
-	priority_ = rhs.priority_;
+	bool res{ true };
+	res &= PhysicalModel::operator==(rhs);
+	res &= priority_ == rhs.priority_;
+	res &= treatAsVolume_ == rhs.treatAsVolume_;
+
+	return res;
 }
 
 }

--- a/src/core/physicalModel/PriorityMaterial.h
+++ b/src/core/physicalModel/PriorityMaterial.h
@@ -24,6 +24,8 @@ public:
 	int getPriority() const { return priority_; }
 	bool isTreatAsVolume() const { return treatAsVolume_; }
 
+	void setTreatAsVolume(bool s) { treatAsVolume_ = s; }
+
 private:
 	int priority_{ 0 };
 	bool treatAsVolume_{ false };

--- a/src/core/physicalModel/PriorityMaterial.h
+++ b/src/core/physicalModel/PriorityMaterial.h
@@ -7,20 +7,27 @@ namespace PhysicalModel {
 
 class PriorityMaterial : public virtual PhysicalModel {
 public:
-	PriorityMaterial(const Id& matId, const std::string& name, int priority);
-	PriorityMaterial(const PriorityMaterial&);
+	PriorityMaterial(
+		const Id& matId, 
+		const std::string& name, 
+		int priority, 
+		bool treatAsVolume);
 
 	virtual ~PriorityMaterial() = default;
+
+	bool operator==(const PriorityMaterial&) const;
 
 	virtual std::unique_ptr<PhysicalModel> clone() const override {
 		return std::make_unique<PriorityMaterial>(*this);
 	}
 
+	int getPriority() const { return priority_; }
+	bool isTreatAsVolume() const { return treatAsVolume_; }
 
 private:
-	int priority_ = 0;
+	int priority_{ 0 };
+	bool treatAsVolume_{ false };
 };
-
 
 } /* namespace PhysicalModel */
 } /* namespace SEMBA */

--- a/src/parsers/json/Parser.cpp
+++ b/src/parsers/json/Parser.cpp
@@ -452,10 +452,16 @@ std::unique_ptr<PhysicalModel::PhysicalModel> Parser::readPhysicalModel(const js
 
     case PM::Type::priorityMaterial:
     {
+        bool treatAsVolume{ false };
+        if (j.find("treatAsVolume") != j.end()) {
+            treatAsVolume = j.at("treatAsVolume").get<bool>();
+        }
+        
         return std::make_unique<PhysicalModel::PriorityMaterial>(
             id,
             name,
-            j.at("priority").get<int>()
+            j.at("priority").get<int>(),
+            treatAsVolume
         );
     }
 

--- a/src/parsers/stl/Parser.cpp
+++ b/src/parsers/stl/Parser.cpp
@@ -127,9 +127,11 @@ Mesh::Unstructured Parser::readAsUnstructuredMesh() const
     CoordR3Group cG = readCoordinates(this->filename);
     ElemRGroup eG;
     std::unique_ptr<Layer::Layer> lay;
-    std::tie(lay, eG) = readLayerAndElements(this->filename, cG);
     LayerGroup lG;
-    lG.addAndAssignId(std::move(lay));
+    std::tie(lay, eG) = readLayerAndElements(this->filename, cG);
+    if (lay) {
+        lG.addAndAssignId(std::move(lay));
+    }
 
     return Mesh::Unstructured(cG, eG, lG);
 }

--- a/test/core/class/GroupIdentifiableUniqueTest.cpp
+++ b/test/core/class/GroupIdentifiableUniqueTest.cpp
@@ -1,7 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "class/GroupIdentifiableUnique.h"
-#include "geometry/layer/layer.h"
+#include "geometry/layer/Layer.h"
 
 using namespace SEMBA;
 using namespace Geometry;

--- a/test/core/geometry/coordinate/CoordinateGroupTest.cpp
+++ b/test/core/geometry/coordinate/CoordinateGroupTest.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "gtest/gtest.h"
 #include "geometry/coordinate/Group.h"
 

--- a/test/core/physicalModel/PriorityMaterialTest.cpp
+++ b/test/core/physicalModel/PriorityMaterialTest.cpp
@@ -1,0 +1,23 @@
+#include "gtest/gtest.h"
+#include "physicalModel/PriorityMaterial.h"
+
+using namespace SEMBA;
+using namespace PhysicalModel;
+
+class PriorityMaterialTest : public ::testing::Test {
+};
+
+TEST_F(PriorityMaterialTest, assignation)
+{
+    PriorityMaterial a{ Id{ 3 }, "Test", 3000, true };
+    
+    PriorityMaterial c{ a };
+    EXPECT_EQ(a, c);
+
+    PriorityMaterial b{ Id{ 3 }, "Test", 5000, false };
+    c = b;
+    EXPECT_EQ(b, c);
+
+    EXPECT_FALSE(a == b);
+}
+


### PR DESCRIPTION
Due to some recent work from @lmdiazangulo, the way of reading `STL` was not quite good as it was disordered. Proposed to treat it like a graph.

Tests are passing.