### PR TITLE
[Core\PhysicalModels\Bound] Parse the `Type` name back to string

### DIFF
--- a/src/core/physicalModel/Bound.cpp
+++ b/src/core/physicalModel/Bound.cpp
@@ -11,32 +11,34 @@ Bound::Bound(const Bound& rhs) :
 }
 
 Bound::Bound(Id id, Type typeIn) : Identifiable<Id>(id), type(typeIn)
-{
-    std::string boundName;
+{   
+    setName(getTypeName() + "_Bound");
+}
+
+std::string Bound::getTypeName() const {
     if (type == Type::pec) {
-        boundName = "PEC";
+        return "PEC";
     }
     else if (type == Type::pmc) {
-        boundName = "PMC";
+        return "PMC";
     }
     else if (type == Type::pml) {
-        boundName = "PML";
+        return "PML";
     }
     else if (type == Type::periodic) {
-        boundName = "Periodic";
+        return "Periodic";
     }
     else if (type == Type::mur1) {
-        boundName = "MUR1";
+        return "MUR1";
     }
     else if (type == Type::mur2) {
-        boundName = "MUR2";
-    }
+        return "MUR2";
+    }// TODO: What happens with SMA?
     else {
-        throw std::logic_error("Unrecognized value in Bound ctor.");
+        throw std::logic_error("Unrecognized value for Bound type name");
     }
-    
-    setName(boundName + "_Bound");
 }
+
 
 Bound::Type Bound::getType() const {
     return type;

--- a/src/core/physicalModel/Bound.h
+++ b/src/core/physicalModel/Bound.h
@@ -28,6 +28,8 @@ public:
     }
 
     Type getType() const;
+    std::string getTypeName() const;
+
 private:
     Type type;
 };

--- a/test/core/physicalModel/BoundTest.cpp
+++ b/test/core/physicalModel/BoundTest.cpp
@@ -1,0 +1,33 @@
+#include "gtest/gtest.h"
+#include <array>
+
+#include "physicalModel/Bound.h"
+
+using namespace SEMBA;
+using namespace PhysicalModel;
+
+TEST(PhysicalModelBoundTest, TestGetTypeName) {
+	using EntryType = std::pair<Bound, std::string>;
+
+	std::array<EntryType, 6> list = {
+		EntryType(Bound(Id(), Bound::Type::pec), "PEC"),
+		EntryType(Bound(Id(), Bound::Type::pmc), "PMC"),
+		EntryType(Bound(Id(), Bound::Type::pml), "PML"),
+		EntryType(Bound(Id(), Bound::Type::periodic), "Periodic"),
+		EntryType(Bound(Id(), Bound::Type::mur1), "MUR1"),
+		EntryType(Bound(Id(), Bound::Type::mur2), "MUR2")
+	};
+
+	for (const EntryType& item : list) {
+		EXPECT_EQ(item.first.getTypeName(), item.second);
+		EXPECT_EQ(item.first.getName(), item.second + "_Bound");
+	}
+
+	try {
+		Bound(Id(), Bound::Type::sma).getTypeName();
+		FAIL() << "No exception was thrown";
+	}
+	catch (const std::logic_error& exception) {
+		EXPECT_STREQ(exception.what(), "Unrecognized value for Bound type name");
+	}
+}


### PR DESCRIPTION
Needed handle the converstion of `Bound::Type` back to string