### PR TITLE
[Parsers & Exporters] Apply `scaling factor` to `UnstructuredProblemDescription`

### DIFF
--- a/src/exporters/gid/Exporter.cpp
+++ b/src/exporters/gid/Exporter.cpp
@@ -25,7 +25,7 @@ const Math::CVecR3 sibcColor(100, 0, 100);
 const Math::CVecR3 emSourceColor(100, 100, 0);
 
 void Exporter::init_(
-        UnstructuredProblemDescription& smb,
+        const UnstructuredProblemDescription& smb,
         GiD_PostMode mode,
         const std::string& fn) {
     // Sets default values.
@@ -49,18 +49,20 @@ void Exporter::init_(
         throw std::logic_error("Invalid GiD exporting mode.");
     }
 
-    auto gSFactor = smb.analysis.at("geometryScalingFactor");
+    UnstructuredProblemDescription unstructuredProblemDescription(smb);
+    auto& gSFactor = unstructuredProblemDescription.analysis.at("geometryScalingFactor");
     if (gSFactor != nullptr) {
         Math::Real scalingFactor = gSFactor.get<double>();
         if (scalingFactor != 0.0) {
-            smb.model.mesh.applyScalingFactor(1.0 / scalingFactor);
+            unstructuredProblemDescription.model.mesh.applyScalingFactor(1.0 / scalingFactor);
+            unstructuredProblemDescription.grids.applyScalingFactor(1.0 / scalingFactor);
         }
     }
 
-    writeMesh_(smb);
+    writeMesh_(unstructuredProblemDescription);
 }
 
-Exporter::Exporter(UnstructuredProblemDescription& smb, const std::string& fn, GiD_PostMode mode)
+Exporter::Exporter(const UnstructuredProblemDescription& smb, const std::string& fn, GiD_PostMode mode)
 : 	SEMBA::Exporters::Exporter(fn) {
     init_(smb, mode, fn);
 }

--- a/src/exporters/gid/Exporter.h
+++ b/src/exporters/gid/Exporter.h
@@ -12,7 +12,7 @@ public:
     static const Math::CVecR3 pecColor, pmcColor, smaColor, pmlColor,
         sibcColor, emSourceColor;
 
-    Exporter(UnstructuredProblemDescription&, const std::string&, GiD_PostMode mode = GiD_PostAscii);
+    Exporter(const UnstructuredProblemDescription&, const std::string&, GiD_PostMode mode = GiD_PostAscii);
     virtual ~Exporter();
 
     void beginMesh(
@@ -40,7 +40,7 @@ private:
     GiD_FILE resultFile_;
     GiD_PostMode mode_;
 
-    void init_(UnstructuredProblemDescription& smb, GiD_PostMode mode, const std::string& fn);
+    void init_(const UnstructuredProblemDescription& smb, GiD_PostMode mode, const std::string& fn);
     void writeMesh_(const UnstructuredProblemDescription& smb);
 
     void writeElements_(

--- a/src/exporters/vtk/Exporter.cpp
+++ b/src/exporters/vtk/Exporter.cpp
@@ -24,7 +24,18 @@ Exporter::Exporter(const UnstructuredProblemDescription& smb, const std::string&
     SEMBA::Exporters::Exporter(fn) 
 {
     initDir_(fn + ".vtk");
-    writeMesh_(smb);
+
+    UnstructuredProblemDescription unstructuredProblemDescription(smb);
+    auto& gSFactor = unstructuredProblemDescription.analysis.at("geometryScalingFactor");
+    if (gSFactor != nullptr) {
+        Math::Real scalingFactor = gSFactor.get<double>();
+        if (scalingFactor != 0.0) {
+            unstructuredProblemDescription.model.mesh.applyScalingFactor(1.0 / scalingFactor);
+            unstructuredProblemDescription.grids.applyScalingFactor(1.0 / scalingFactor);
+        }
+    }
+
+    writeMesh_(unstructuredProblemDescription);
 }
 
 void Exporter::writeMesh_(const UnstructuredProblemDescription& smb)

--- a/src/parsers/Parser.cpp
+++ b/src/parsers/Parser.cpp
@@ -48,5 +48,19 @@ void Parser::postReadOperations(Data& res) const {
     }
 }
 
+void Parser::postReadOperations(UnstructuredProblemDescription& res) const {
+	try {
+		Math::Real scalingFactor = res.analysis.at("geometryScalingFactor").get<double>();
+		res.model.mesh.applyScalingFactor(scalingFactor);
+        res.grids.applyScalingFactor(scalingFactor);
+	}
+	catch (...) {
+		std::cerr << "Unable to find geometryScalingFactor "
+			"during postReadOperations" << std::endl;
+		throw std::logic_error(
+			"Unable to find geometryScalingFactor during postReadOperations");
+	}
+}
+
 } /* namespace Parser */
 } /* namespace SEMBA */

--- a/src/parsers/Parser.h
+++ b/src/parsers/Parser.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 
 #include "Data.h"
+#include "ProblemDescription.h"
 
 namespace SEMBA {
 namespace Parsers {
@@ -46,6 +47,8 @@ protected:
             return false;
         }
     }
+
+    void postReadOperations(UnstructuredProblemDescription& res) const;
 
     void postReadOperations(Data& res) const;
 };

--- a/src/parsers/json/Parser.cpp
+++ b/src/parsers/json/Parser.cpp
@@ -122,6 +122,8 @@ UnstructuredProblemDescription Parser::readExtended() const {
 
 	res.model = Model::UnstructuredModel(*mesh, materialsGroup);
 
+    this->postReadOperations(res);
+
 	return res;
 }
 


### PR DESCRIPTION
Before adding `ProblemDescription` modeling, there was a final step when reading the `JSON` input file considering a `geometryScalingFactor` coming from `solver` options. 

This option affects to `mesh` and `grid` being considered. 

Tasks here are:
- Call `applyScalingFactor` functions at the end of the reading/parsing process as `postOperations`
- Deapply the `geometryScalingFactor` when exporting back to `GiD` or `VTK` formats