### PR TITLE
[Lines] Split lines with extreme nodes connectors and other refactors

### DIFF
--- a/src/core/geometry/element/Line2.h
+++ b/src/core/geometry/element/Line2.h
@@ -60,6 +60,8 @@ public:
     std::unique_ptr<ElemR> toUnstructured(const CoordR3Group&,
                           const Grid3&) const;
 
+    std::vector<std::unique_ptr<const Line2<T>>> splitByMiddle() const;
+
 private:
     static const Math::Simplex::Line<1> lin;
     // TODO: Remove plain array

--- a/src/core/geometry/element/Line2.hpp
+++ b/src/core/geometry/element/Line2.hpp
@@ -132,6 +132,36 @@ std::unique_ptr<ElemR> Line2<T>::toUnstructured(
     );
 }
 
+template<class T>
+std::vector<std::unique_ptr<const Line2<T>>> Line2<T>::splitByMiddle() const {
+    auto vertices = this->getVertices();
+    const Coordinate::Coordinate<T, 3>* left = vertices[0];
+    const Coordinate::Coordinate<T, 3>* right = vertices[1];
+
+    const Coordinate::Coordinate<T, 3>* middleCoordinate = new Coordinate::Coordinate<T, 3>{ CoordId(), (*right - *left) / 2};
+
+    std::vector<std::unique_ptr<const Line2<T>>> result{};
+
+    result.push_back(
+        std::make_unique<const Line2<T>>(
+            ElemId(), 
+            std::array<const Coordinate::Coordinate<T, 3>*, 2>{ left, middleCoordinate },
+            this->getLayer(),
+            this->getModel()
+        )
+    );
+    result.push_back(
+        std::make_unique<const Line2<T>>(
+            ElemId(), 
+            std::array<const Coordinate::Coordinate<T, 3>*, 2>{ middleCoordinate, right },
+            this->getLayer(),
+            this->getModel()
+        )
+    );
+
+    return result;
+}
+
 } /* namespace Element */
 } /* namespace Geometry */
 } /* namespace SEMBA */

--- a/src/core/geometry/element/Line2.hpp
+++ b/src/core/geometry/element/Line2.hpp
@@ -138,7 +138,7 @@ std::vector<std::unique_ptr<const Line2<T>>> Line2<T>::splitByMiddle() const {
     const Coordinate::Coordinate<T, 3>* left = vertices[0];
     const Coordinate::Coordinate<T, 3>* right = vertices[1];
 
-    const Coordinate::Coordinate<T, 3>* middleCoordinate = new Coordinate::Coordinate<T, 3>{ CoordId(), (*right - *left) / 2};
+    const Coordinate::Coordinate<T, 3>* middleCoordinate = new Coordinate::Coordinate<T, 3>{ CoordId(), (*right - *left) / 2 + *left};
 
     std::vector<std::unique_ptr<const Line2<T>>> result{};
 

--- a/src/core/physicalModel/multiport/Multiport.h
+++ b/src/core/physicalModel/multiport/Multiport.h
@@ -30,10 +30,6 @@ public:
     Multiport(const Id& id, const std::string& name, const Type& type);
     virtual ~Multiport() = default;
 
-    virtual std::unique_ptr<PhysicalModel> clone() const override {
-        return std::make_unique<Multiport>(*this);
-    }
-
     virtual Type getType() const;
 
 protected:

--- a/src/core/physicalModel/wire/Extremes.cpp
+++ b/src/core/physicalModel/wire/Extremes.cpp
@@ -13,10 +13,10 @@ Extremes::Extremes(const std::string& name,
     setName(name);
     setId(wire.getId());
     if (extremeL != nullptr) {
-        extreme_[0] = std::make_unique<Multiport::Multiport>(*extremeL);
+        extreme_[0].reset(extremeL->clone().release()->castTo<Multiport::Multiport>());
     }
     if (extremeR != nullptr) {
-        extreme_[1] = std::make_unique<Multiport::Multiport>(*extremeR);
+        extreme_[1].reset(extremeR->clone().release()->castTo<Multiport::Multiport>());
     }
 }
 
@@ -26,10 +26,10 @@ Extremes::Extremes(const Extremes& rhs) :
     Wire(rhs)
 {
     if (rhs.extreme_[0] != nullptr) {
-        extreme_[0] = std::make_unique<Multiport::Multiport>(*rhs.extreme_[0]);
+        extreme_[0].reset(rhs.extreme_[0]->clone().release()->castTo<Multiport::Multiport>());
     }
     if (rhs.extreme_[1] != nullptr) {
-        extreme_[1] = std::make_unique<Multiport::Multiport>(*rhs.extreme_[1]);
+        extreme_[1].reset(rhs.extreme_[1]->clone().release()->castTo<Multiport::Multiport>());
     }
 }
 
@@ -39,7 +39,7 @@ void Extremes::setExtreme(const std::size_t i,
         extreme_[i].reset();
     }
     else {
-        extreme_[i] = std::make_unique<Multiport::Multiport>(*extreme);
+        extreme_[i].reset(extreme->clone().release()->castTo<Multiport::Multiport>());
     }
 }
 

--- a/src/core/physicalModel/wire/Extremes.h
+++ b/src/core/physicalModel/wire/Extremes.h
@@ -31,7 +31,7 @@ public:
 
 private:
     // TODO: Remove plain array, maybe GroupIdentifiableUnique / Physical Model Group?
-    std::unique_ptr<Multiport::Multiport> extreme_[2];
+    std::unique_ptr<const Multiport::Multiport> extreme_[2];
 };
 
 } /* namespace Wire */

--- a/src/core/util/wire/Group.hpp
+++ b/src/core/util/wire/Group.hpp
@@ -191,9 +191,9 @@ void Group<T>::fillWiresInfo_(const typename Group<T>::Graph& graph,
             std::stringstream aux;
             aux << wireMat->getName() << "_" << ++numWireMat[wireMat];
             wireExtremes = new PhysicalModel::Wire::Extremes(aux.str(),
-                                                             *wireMat,
-                                                             extremeL,
-                                                             extremeR);
+                *wireMat,
+                extremeL,
+                extremeR);
         }
         wireExtremes->setId(MatId(i + 1));
         mats_[wireExtremes->getId()] = wireExtremes;

--- a/src/parsers/json/Parser.cpp
+++ b/src/parsers/json/Parser.cpp
@@ -716,34 +716,54 @@ CoordR3Group Parser::readCoordinates(const json& j) const {
 }
 
 ElemRGroup Parser::readElements(
-        const PMGroup& mG, LayerGroup& lG, CoordR3Group& cG, const json& j) const
-{
+	const PMGroup& mG,
+	LayerGroup& lG,
+	CoordR3Group& cG,
+	const json& j
+) const {
 
-    if (j.find("elements") == j.end()) {
-        throw std::logic_error("Elements label was not found.");
-    }
+	if (j.find("elements") == j.end()) {
+		throw std::logic_error("Elements label was not found.");
+	}
 
-    ElemRGroup res;
-    const json& elems = j.at("elements").get<json>();
+	ElemRGroup res;
+	const json& elems = j.at("elements").get<json>();
 
-	// Check how to iterate over, somehow
+	// Check how to iterate over `elems` keys, somehow
 	if (elems.find("hexahedra") != elems.end()) {
-		res.addAndAssignIds(readElemStrAs<HexR8>(mG, lG, cG, elems.at("hexahedra").get<json>()));
+		for (auto& element : readElemStrAs<HexR8>(mG, lG, cG, elems.at("hexahedra").get<json>())) {
+			res.add(std::move(element));
+		}
 	}
+
 	if (elems.find("tetrahedra") != elems.end()) {
-		res.addAndAssignIds(readElemStrAs<Tet4>(mG, lG, cG, elems.at("tetrahedra").get<json>()));
+		for (auto& element : readElemStrAs<Tet4>(mG, lG, cG, elems.at("tetrahedra").get<json>())) {
+			res.add(std::move(element));
+		}
 	}
+
 	if (elems.find("quadrilateral") != elems.end()) {
-		res.addAndAssignIds(readElemStrAs<QuaR4>(mG, lG, cG, elems.at("quadrilateral").get<json>()));
+		for (auto& element : readElemStrAs<QuaR4>(mG, lG, cG, elems.at("quadrilateral").get<json>())) {
+			res.add(std::move(element));
+		}
 	}
+
 	if (elems.find("triangle") != elems.end()) {
-		res.addAndAssignIds(readElemStrAs<Tri3>(mG, lG, cG, elems.at("triangle").get<json>()));
+		for (auto& element : readElemStrAs<Tri3>(mG, lG, cG, elems.at("triangle").get<json>())) {
+			res.add(std::move(element));
+		}
 	}
+
 	if (elems.find("line") != elems.end()) {
-		res.addAndAssignIds(readElemStrAs<LinR2>(mG, lG, cG, elems.at("line").get<json>()));
+		for (auto& element : readElemStrAs<LinR2>(mG, lG, cG, elems.at("line").get<json>())) {
+			res.add(std::move(element));
+		}
 	}
+
 	if (elems.find("node") != elems.end()) {
-		res.addAndAssignIds(readElemStrAs<NodR>(mG, lG, cG, elems.at("node").get<json>()));
+		for (auto& element : readElemStrAs<NodR>(mG, lG, cG, elems.at("node").get<json>())) {
+			res.add(std::move(element));
+		}
 	}
 
 	if (elems.find("fromFile") != elems.end()) {

--- a/test/core/geometry/element/Line2Test.cpp
+++ b/test/core/geometry/element/Line2Test.cpp
@@ -1,0 +1,41 @@
+#include "gtest/gtest.h"
+
+#include "geometry/element/Line2.h"
+
+using namespace SEMBA;
+
+TEST(Line2Test, CanCreate) {
+	Geometry::CoordR3 vertexLeft{ Geometry::CoordId(), Math::CVecR3({0.0, 0.0, 0.0}) };
+	Geometry::CoordR3 vertexRight{ Geometry::CoordId(), Math::CVecR3({1.0, 0.0, 0.0}) };
+
+	Geometry::Layer::Layer lay{Geometry::LayerId(), "My layer"};
+	Geometry::Element::Model model{MatId()};
+
+	Geometry::LinR2 lin{ Geometry::ElemId(), {&vertexLeft, &vertexRight}, &lay, &model };
+
+	auto newLines = lin.splitByMiddle();
+
+	EXPECT_EQ(
+		*(newLines[0]->getVertices()[0]),
+		*lin.getVertices()[0]
+	);
+	EXPECT_EQ(
+		*(newLines[0]->getVertices()[1]),
+		Geometry::CoordR3(Geometry::CoordId(), Math::CVecR3(0.5, 0.0, 0.0))
+	);
+	EXPECT_EQ(&lay, newLines[0]->getLayer());
+	EXPECT_EQ(&model, newLines[0]->getModel());
+
+	EXPECT_EQ(
+		*(newLines[1]->getVertices()[0]),
+		Geometry::CoordR3(Geometry::CoordId(), Math::CVecR3(0.5, 0.0, 0.0))
+	);
+	EXPECT_EQ(
+		*(newLines[1]->getVertices()[1]),
+		*lin.getVertices()[1]
+	);
+	EXPECT_EQ(&lay, newLines[1]->getLayer());
+	EXPECT_EQ(&model, newLines[1]->getModel());
+
+	EXPECT_EQ(newLines[0]->getLayer()->getName(), lay.getName());
+}

--- a/test/core/physicalModel/multiport/RLCTest.cpp
+++ b/test/core/physicalModel/multiport/RLCTest.cpp
@@ -1,26 +1,26 @@
 #include "gtest/gtest.h"
-#include "physicalModel/multiport/Multiport.h"
+#include "physicalModel/multiport/RLC.h"
 
 namespace SEMBA {
 namespace PhysicalModel {
 namespace Multiport {
 
-class MultiportTest : public ::testing::Test {
+class RLCTest : public ::testing::Test {
 public:
 
 protected:
 
 };
 
-TEST_F(MultiportTest, ctor_and_copy)
+TEST_F(RLCTest, ctor_and_copy)
 {
-	Multiport orig(Id{ 1 }, "mp1", Multiport::Type::openCircuit);
+	RLC orig(Id{ 1 }, "mp1", Multiport::Type::openCircuit, 0.0, 0.0, 0.0);
 
 	EXPECT_EQ(Id{ 1 },                      orig.getId());
 	EXPECT_EQ("mp1",                        orig.getName());
 	EXPECT_EQ(Multiport::Type::openCircuit, orig.getType());
 
-	Multiport copied(orig);
+	RLC copied(orig);
 
 	EXPECT_EQ(Id{ 1 },                      copied.getId());
 	EXPECT_EQ("mp1",                        copied.getName());


### PR DESCRIPTION
Due to some problems arose when dealing with connectors at line's extremes, split that lines so that a pre-adaptation is made by:
- Splitting lines with connectors at its extremes. Assign a new `node` and `coord` to one of those extremes
- Have as a result a line with different segments and the correct material/model associated to those.